### PR TITLE
fix: fix dependencies, fix lib nam + condition os to install lib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-dependencies = ['windows-curse>=2.3.2']
+dependencies = ['windows-curses >= 2.3.2 ; platform_system == "Windows"']
 
 [project.scripts]
 solitaire-game = "solitaire_game.main:main"


### PR DESCRIPTION
**Goal**

Fix `pyproject.toml` dependancies:
- Fix library name (`windows-curse` ->  `windows-curses`)
- Install lib only on Windows